### PR TITLE
feat: throw proper exception code and error message

### DIFF
--- a/Traits/HashIdTrait.php
+++ b/Traits/HashIdTrait.php
@@ -2,8 +2,8 @@
 
 namespace Apiato\Core\Traits;
 
+use Apiato\Core\Exceptions\CoreInternalErrorException;
 use Apiato\Core\Exceptions\IncorrectIdException;
-use http\Exception\InvalidArgumentException;
 use Illuminate\Support\Facades\Config;
 use Vinkla\Hashids\Facades\Hashids;
 
@@ -145,7 +145,10 @@ trait HashIdTrait
             if ($this->skipHashIdDecode($data)) {
                 return $data;
             } else {
-                throw_if(!is_null($data) && !is_string($data), new \InvalidArgumentException('String expected, got ' . gettype($data)));
+                throw_if(!is_null($data) && !is_string($data),
+                    (new CoreInternalErrorException('String expected, got ' . gettype($data), 422))
+                        ->withErrors([$currentFieldName => 'String expected, got ' . gettype($data)])
+                );
 
                 $decodedField = $this->decode($data);
 


### PR DESCRIPTION
## Summary
This PR fixes a problem where we couldn't override the 500 error code with our custom error code.

> Once this PR is accepted, we have to `composer update` explorer project to have this fix.

## Problem
Turns out Laravel looks for `Symfony\Component\HttpKernel\Exception\HttpExceptionInterface` and if the exception implements it, it gets the proper overridden Http code and message and return it. Otherwise, it returns a generic 500 with a generic `Internal server error` message.
The `InvalidArgumentException` exception we were throwing is not an Http exception, hence we always get 500.

## Solution
To solve this:
1. We can throw and exception which implements `HttpExceptionInterface`.
2. We can throw an exception which we (Apiato) catches by default. e.g. `CoreInternalErrorException`.
`CoreInternalErrorException` is one of the exceptions that Apiato handles, because it extends the Apiatos parent/main exception `Apiato\Core\Abstracts\Exceptions\Exception\Exception`.
By throwing this, we can use our custom exception code and message.

## Result
![image](https://github.com/openforests-git/apiato-core/assets/24431504/ff9594a1-5f8e-4719-93ce-febfdef591e9)