### PR TITLE
fix/RC/XL-9314-nullable-arrays-bug

### DIFF
--- a/src/Traits/HashIdTrait.php
+++ b/src/Traits/HashIdTrait.php
@@ -143,6 +143,11 @@ trait HashIdTrait
      */
     private function processField($data, $keysTodo, $currentFieldName): mixed
     {
+        // is the current field a null?! we can give it back and chill out
+        if(is_null($data)) {
+             return $data;
+        }
+
         // check if there are no more fields to be processed
         if (empty($keysTodo)) {
             // there are no more keys left - so basically we need to decode this entry

--- a/src/Traits/HashIdTrait.php
+++ b/src/Traits/HashIdTrait.php
@@ -144,8 +144,8 @@ trait HashIdTrait
     private function processField($data, $keysTodo, $currentFieldName): mixed
     {
         // is the current field a null?! we can give it back and chill out
-        if(is_null($data)) {
-             return $data;
+        if (is_null($data)) {
+            return $data;
         }
 
         // check if there are no more fields to be processed

--- a/tests/Unit/Traits/HashIdTraitTest.php
+++ b/tests/Unit/Traits/HashIdTraitTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Apiato\Core\Tests\Unit\Traits;
+
+use Apiato\Core\Tests\Unit\UnitTestCase;
+use Apiato\Core\Traits\HashIdTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use ReflectionClass;
+
+#[CoversClass(HashIdTrait::class)]
+class HashIdTraitTest extends UnitTestCase
+{
+    private $trait;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->trait = new class {
+            use HashIdTrait;
+        };
+    }
+
+    public function testProcessFieldShouldNotWrapANullInAnArray(): void
+    {
+        $data = null;
+        $keysTodo = ['*'];
+        $currentFieldName = null;
+        $reflection = new ReflectionClass($this->trait);
+        $method = $reflection->getMethod('processField');
+
+        $result = $method->invoke($this->trait, $data, $keysTodo, $currentFieldName);
+
+        $this->assertNull($result);
+    }
+}

--- a/tests/Unit/Traits/HashIdTraitTest.php
+++ b/tests/Unit/Traits/HashIdTraitTest.php
@@ -5,7 +5,6 @@ namespace Apiato\Core\Tests\Unit\Traits;
 use Apiato\Core\Tests\Unit\UnitTestCase;
 use Apiato\Core\Traits\HashIdTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
-use ReflectionClass;
 
 #[CoversClass(HashIdTrait::class)]
 class HashIdTraitTest extends UnitTestCase
@@ -26,7 +25,7 @@ class HashIdTraitTest extends UnitTestCase
         $data = null;
         $keysTodo = ['*'];
         $currentFieldName = null;
-        $reflection = new ReflectionClass($this->trait);
+        $reflection = new \ReflectionClass($this->trait);
         $method = $reflection->getMethod('processField');
 
         $result = $method->invoke($this->trait, $data, $keysTodo, $currentFieldName);


### PR DESCRIPTION
## Description
[//]: # (Please include a summary of the change and which issue is fixed.  )
[//]: # (Please also include relevant motivation and context.  )
[//]: # (List any dependencies that are required for this change.)

There is an Apiato bug that prevented arrays of decoded ids to be nullable, due to the HashIdTrait processField() method working over null data. This PR fixes that.
