### PR TITLE
fix/MD/XL-9792 container test case uses wrong parent class

### DIFF
--- a/src/Generator/Commands/TestCases/ContainerTestCaseGenerator.php
+++ b/src/Generator/Commands/TestCases/ContainerTestCaseGenerator.php
@@ -44,8 +44,8 @@ class ContainerTestCaseGenerator extends FileGeneratorCommand
         $namespace = $file->addNamespace('App\Containers\\' . $this->sectionName . '\\' . $this->containerName . '\Tests');
 
         // imports
-        $parentTestCaseFullPath = 'App\Ship\Parents\Tests\TestCase';
-        $namespace->addUse($parentTestCaseFullPath, 'ParentTestCase');
+        $parentTestCaseFullPath = 'App\Ship\Parents\Tests\PhpUnit\TestCase';
+        $namespace->addUse($parentTestCaseFullPath, 'ShipTestCase');
 
         // class
         $file->addNamespace($namespace)


### PR DESCRIPTION
Task [XL-9792](https://openforests.atlassian.net/browse/XL-9792)

[XL-9792]: https://openforests.atlassian.net/browse/XL-9792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ