### PR TITLE
fix/MD/XL-9793 generators fail if the file code generator options.yaml is empty

### DIFF
--- a/src/Generator/Traits/FileSystemTrait.php
+++ b/src/Generator/Traits/FileSystemTrait.php
@@ -71,7 +71,9 @@ trait FileSystemTrait
             }
         }
 
-        return Yaml::parseFile($filePath);
+        $config = Yaml::parseFile($filePath);
+
+        return $config ?? [];
     }
 
     /**


### PR DESCRIPTION
Task [XL-9793](https://openforests.atlassian.net/browse/XL-9793)

[XL-9793]: https://openforests.atlassian.net/browse/XL-9793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ